### PR TITLE
Early stopping

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        coverage run --source=globalemu -m py.test
+        coverage run --source=globalemu -m pytest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :globalemu: Robust Global 21-cm Signal Emulation
 :Author: Harry Thomas Jones Bevins
-:Version: 1.5.2
+:Version: 1.6.0
 :Homepage: https://github.com/htjb/globalemu
 :Documentation: https://globalemu.readthedocs.io/
 

--- a/globalemu/eval.py
+++ b/globalemu/eval.py
@@ -246,5 +246,5 @@ class evaluate():
 
         if type(evaluation) is not np.ndarray:
             evaluation = np.array(evaluation)
-        
+
         return evaluation, self.z

--- a/globalemu/network.py
+++ b/globalemu/network.py
@@ -295,9 +295,9 @@ class nn():
             test_loss_results.append(test_loss)
             
             print(
-                'Epoch: {:03d}, Loss: {:.5f}, RMSE: {:.5f}, Time: {:.3f}'
+                'Epoch: {:03d}, Loss: {:.5f}, Test Loss: {:.5f}, RMSE: {:.5f}, Time: {:.3f}'
                 .format(
-                    epoch, epoch_loss_avg.result(),
+                    epoch, epoch_loss_avg.result(), test_loss_results[-1],
                     epoch_rmse_avg.result(), e-s))
 
             if self.early_stop:

--- a/globalemu/network.py
+++ b/globalemu/network.py
@@ -307,9 +307,9 @@ class nn():
                         (test_loss_results[-21] + test_loss_results[-1])
                         
                     if delta*100 < 1e-2:
-                        print('Early Stopped:' + str(delta.numpy()*100) +
+                        print('Early Stopped: {:.5f}'.format(delta.numpy()*100) +
                               ' < 1e-2')
-                        print('Epochs used = ' + str(i))
+                        print('Epochs used = ' + str(len(test_loss_results)))
                         break
             
             if (epoch + 1) % 10 == 0:

--- a/globalemu/network.py
+++ b/globalemu/network.py
@@ -74,7 +74,7 @@ class nn():
 
         early_stop: **Bool / default: False**
             | If ``early_stop`` is set too ``True`` then the network will stop
-                learning if the loss has not changed within 
+                learning if the loss has not changed within
                 the last twenty epochs.
 
         xHI: **Bool / default: False**
@@ -290,28 +290,29 @@ class nn():
             train_loss_results.append(epoch_loss_avg.result())
             train_rmse_results.append(epoch_rmse_avg.result())
             e = time.time()
-            
+
             test_loss, _ = loss(model, test_data, test_labels, training=False)
             test_loss_results.append(test_loss)
-            
+
             print(
-                'Epoch: {:03d}, Loss: {:.5f}, Test Loss: {:.5f}, RMSE: {:.5f}, Time: {:.3f}'
-                .format(
-                    epoch, epoch_loss_avg.result(), test_loss_results[-1],
-                    epoch_rmse_avg.result(), e-s))
+                'Epoch: {:03d}, Loss: {:.5f}, Test Loss: {:.5f},'
+                .format(epoch, epoch_loss_avg.result(), test_loss_results[-1])
+                + 'RMSE: {:.5f}, Time: {:.3f}'
+                .format(epoch_rmse_avg.result(), e-s))
 
             if self.early_stop:
                 if len(test_loss_results) > 20:
-                    delta = 2*np.abs(test_loss_results[-21] - \
-                        test_loss_results[-1])/ \
-                        (test_loss_results[-21] + test_loss_results[-1])
-                        
+                    delta = 2*np.abs(test_loss_results[-21] -
+                                     test_loss_results[-1]) / \
+                                     (test_loss_results[-21] +
+                                      test_loss_results[-1])
+
                     if delta*100 < 1e-2:
-                        print('Early Stopped: {:.5f}'.format(delta.numpy()*100) +
-                              ' < 1e-2')
+                        print('Early Stopped: {:.5f}'.format(delta.numpy()*100)
+                              + ' < 1e-2')
                         print('Epochs used = ' + str(len(test_loss_results)))
                         break
-            
+
             if (epoch + 1) % 10 == 0:
                 model.save(self.base_dir + 'model.h5')
                 np.savetxt(

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -154,7 +154,7 @@ class process():
         full_train_data = load_data('train_data.txt')
         full_train_labels = load_data('train_labels.txt')
         full_test_data = load_data('test_data.txt')
-        full_test_labels = load_data('test_labels.txt')
+        test_labels = load_data('test_labels.txt')
 
         if self.preprocess_settings['AFB'] is True:
             np.save(
@@ -166,7 +166,7 @@ class process():
             train_data = full_train_data.copy()
             if self.preprocess_settings['AFB'] is True:
                 train_labels = full_train_labels.copy() - res.deltaT
-                full_test_labels -= res.deltaT
+                test_labels -= res.deltaT
             else:
                 train_labels = full_train_labels.copy()
         else:
@@ -227,9 +227,9 @@ class process():
             norm_s = np.interp(samples, self.z, cdf)
 
             resampled_test_labels = []
-            for i in range(len(full_test_labels)):
+            for i in range(len(test_labels)):
                 resampled_test_labels.append(
-                    np.interp(samples, self.z, full_test_labels[i]))
+                    np.interp(samples, self.z, test_labels[i]))
             test_labels = np.array(resampled_test_labels)
         else:
             norm_s = (self.z - self.z.min())/(self.z.max() - self.z.min())

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -100,7 +100,8 @@ class process():
         if type(z) not in set([np.ndarray, list]):
             raise TypeError("'z' should be a numpy array or list.")
 
-        # Convert to numpy array, and cast to float to avoid NaN errors in AFB later
+        # Convert to numpy array, and cast to float to
+        # avoid NaN errors in AFB later
         z = np.array(z, dtype=float)
         self.z = z
 
@@ -246,15 +247,15 @@ class process():
         norm_train_data = []
         for i in range(train_data.shape[1]):
             norm_train_data.append(
-                (train_data[:, i] - train_data_mins[i])/ \
-                    (train_data_maxs[i]-train_data_mins[i]))
+                                   (train_data[:, i] - train_data_mins[i]) /
+                                   (train_data_maxs[i] - train_data_mins[i]))
         norm_train_data = np.array(norm_train_data).T
 
         norm_test_data = []
         for i in range(test_data.shape[1]):
             norm_test_data.append(
-                (test_data[:, i] - test_data_mins[i])/ \
-                    (test_data_maxs[i]-test_data_mins[i]))
+                                  (test_data[:, i] - test_data_mins[i]) /
+                                  (test_data_maxs[i] - test_data_mins[i]))
         norm_test_data = np.array(norm_test_data).T
 
         if self.preprocess_settings['std_division'] is True:
@@ -298,7 +299,7 @@ class process():
                     np.hstack([norm_test_data[i, :], norm_s[j]]))
         flattened_test_data = np.array(flattened_test_data)
 
-        train_dataset = np.hstack([flattened_train_data, 
+        train_dataset = np.hstack([flattened_train_data,
                                    norm_train_labels[:, np.newaxis]])
 
         np.savetxt(

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -146,12 +146,15 @@ class process():
 
         np.savetxt(self.base_dir + 'z.txt', self.z)
 
-        full_train_data = pd.read_csv(
-            self.data_location + 'train_data.txt',
-            delim_whitespace=True, header=None).values
-        full_train_labels = pd.read_csv(
-            self.data_location + 'train_labels.txt',
-            delim_whitespace=True, header=None).values
+        def load_data(file):
+            return pd.read_csv(
+                self.data_location + file,
+                delim_whitespace=True, header=None).values
+
+        full_train_data = load_data('train_data.txt')
+        full_train_labels = load_data('train_labels.txt')
+        full_test_data = load_data('test_data.txt')
+        full_test_labels = load_data('test_labels.txt')
 
         if self.preprocess_settings['AFB'] is True:
             np.save(
@@ -163,6 +166,7 @@ class process():
             train_data = full_train_data.copy()
             if self.preprocess_settings['AFB'] is True:
                 train_labels = full_train_labels.copy() - res.deltaT
+                test_labels = full_test_labels.copy() - res.deltaT
             else:
                 train_labels = full_train_labels.copy()
         else:
@@ -186,16 +190,27 @@ class process():
             train_data, train_labels = np.array(train_data), \
                 np.array(train_labels)
 
-        log_td = []
+        log_train_data = []
         for i in range(train_data.shape[1]):
             if i in set(self.logs):
                 for j in range(train_data.shape[0]):
                     if train_data[j, i] == 0:
                         train_data[j, i] = 1e-6
-                log_td.append(np.log10(train_data[:, i]))
+                log_train_data.append(np.log10(train_data[:, i]))
             else:
-                log_td.append(train_data[:, i])
-        train_data = np.array(log_td).T
+                log_train_data.append(train_data[:, i])
+        train_data = np.array(log_train_data).T
+
+        log_test_data = []
+        for i in range(full_test_data.shape[1]):
+            if i in set(self.logs):
+                for j in range(full_test_data.shape[0]):
+                    if full_test_data[j, i] == 0:
+                        full_test_data[j, i] = 1e-6
+                log_test_data.append(np.log10(full_test_data[:, i]))
+            else:
+                log_test_data.append(full_test_data[:, i])
+        test_data = np.array(log_test_data).T
 
         if self.preprocess_settings['resampling'] is True:
             sampling_call = sampling(
@@ -210,17 +225,34 @@ class process():
             train_labels = np.array(resampled_labels)
 
             norm_s = np.interp(samples, self.z, cdf)
+
+            resampled_test_labels = []
+            for i in range(len(test_labels)):
+                resampled_test_labels.append(
+                    np.interp(samples, self.z, test_labels[i]))
+            test_labels = np.array(resampled_test_labels)
         else:
             norm_s = (self.z - self.z.min())/(self.z.max() - self.z.min())
 
-        data_mins = train_data.min(axis=0)
-        data_maxs = train_data.max(axis=0)
+        train_data_mins = train_data.min(axis=0)
+        train_data_maxs = train_data.max(axis=0)
+
+        test_data_mins = test_data.min(axis=0)
+        test_data_maxs = test_data.max(axis=0)
 
         norm_train_data = []
         for i in range(train_data.shape[1]):
             norm_train_data.append(
-                (train_data[:, i] - data_mins[i])/(data_maxs[i]-data_mins[i]))
+                (train_data[:, i] - train_data_mins[i])/ \
+                    (train_data_maxs[i]-train_data_mins[i]))
         norm_train_data = np.array(norm_train_data).T
+
+        norm_test_data = []
+        for i in range(test_data.shape[1]):
+            norm_test_data.append(
+                (test_data[:, i] - test_data_mins[i])/ \
+                    (test_data_maxs[i]-test_data_mins[i]))
+        norm_test_data = np.array(norm_test_data).T
 
         if self.preprocess_settings['std_division'] is True:
             labels_stds = train_labels.std()
@@ -231,13 +263,23 @@ class process():
 
             norm_train_labels = norm_train_labels.flatten()
             np.save(self.base_dir + 'labels_stds.npy', labels_stds)
+
+            test_labels_stds = test_labels.std()
+            norm_test_labels = [
+                test_labels[i, :]/test_labels_stds
+                for i in range(test_labels.shape[0])]
+            norm_test_labels = np.array(norm_test_labels)
+
+            norm_test_labels = norm_test_labels.flatten()
+
         else:
             norm_train_labels = train_labels.flatten()
+            norm_test_labels = test_labels.flatten()
 
         if self.num != 'full':
             np.savetxt(self.base_dir + 'indices.txt', ind)
-        np.savetxt(self.base_dir + 'data_mins.txt', data_mins)
-        np.savetxt(self.base_dir + 'data_maxs.txt', data_maxs)
+        np.savetxt(self.base_dir + 'data_mins.txt', train_data_mins)
+        np.savetxt(self.base_dir + 'data_maxs.txt', train_data_maxs)
 
         flattened_train_data = []
         for i in range(len(norm_train_data)):
@@ -246,12 +288,21 @@ class process():
                     np.hstack([norm_train_data[i, :], norm_s[j]]))
         flattened_train_data = np.array(flattened_train_data)
 
-        train_data, train_label = flattened_train_data, norm_train_labels
-        train_dataset = np.hstack([train_data, train_label[:, np.newaxis]])
+        flattened_test_data = []
+        for i in range(len(norm_test_data)):
+            for j in range(len(norm_s)):
+                flattened_test_data.append(
+                    np.hstack([norm_test_data[i, :], norm_s[j]]))
+        flattened_test_data = np.array(flattened_test_data)
+
+        train_dataset = np.hstack([flattened_train_data, 
+                                   norm_train_labels[:, np.newaxis]])
 
         np.savetxt(
             self.base_dir + 'train_dataset.csv', train_dataset, delimiter=',')
-        np.savetxt(self.base_dir + 'train_data.txt', train_data)
-        np.savetxt(self.base_dir + 'train_label.txt', train_label)
+        np.savetxt(self.base_dir + 'train_data.txt', flattened_train_data)
+        np.savetxt(self.base_dir + 'train_label.txt', norm_train_labels)
+        np.savetxt(self.base_dir + 'test_data.txt', flattened_test_data)
+        np.savetxt(self.base_dir + 'test_label.txt', norm_test_labels)
 
         print('...preprocessing done.')

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -166,7 +166,7 @@ class process():
             train_data = full_train_data.copy()
             if self.preprocess_settings['AFB'] is True:
                 train_labels = full_train_labels.copy() - res.deltaT
-                test_labels = full_test_labels.copy() - res.deltaT
+                full_test_labels -= res.deltaT
             else:
                 train_labels = full_train_labels.copy()
         else:
@@ -227,9 +227,9 @@ class process():
             norm_s = np.interp(samples, self.z, cdf)
 
             resampled_test_labels = []
-            for i in range(len(test_labels)):
+            for i in range(len(full_test_labels)):
                 resampled_test_labels.append(
-                    np.interp(samples, self.z, test_labels[i]))
+                    np.interp(samples, self.z, full_test_labels[i]))
             test_labels = np.array(resampled_test_labels)
         else:
             norm_s = (self.z - self.z.min())/(self.z.max() - self.z.min())

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='globalemu',
-    version='1.5.2',
+    version='1.6.0',
     description='globalemu: Robust and Fast Global 21-cm Signal Emulation',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,6 +5,7 @@ import requests
 import pandas as pd
 import numpy as np
 
+
 def download_21cmGEM_data():
     data_dir = '21cmGEM_data/'
     if not os.path.exists(data_dir):
@@ -33,6 +34,7 @@ def download_21cmGEM_data():
 
     np.savetxt(data_dir + 'train_data.txt', td[:500, :])
     np.savetxt(data_dir + 'train_labels.txt', tl[:500, :])
+
 
 def test_existing_dir():
     if os.path.exists('kappa_HH.txt'):

--- a/tests/test_gui_config.py
+++ b/tests/test_gui_config.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from globalemu.gui_config import config
 from globalemu.downloads import download
-import requests
 import shutil
 import os
 import pytest

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2,7 +2,6 @@ import numpy as np
 from globalemu.preprocess import process
 from globalemu.network import nn
 from tensorflow.keras import backend as K
-import requests
 import os
 import shutil
 import pytest

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -57,8 +57,6 @@ def test_process_nn():
     with pytest.raises(TypeError):
         nn(early_stop='foo')
     with pytest.raises(TypeError):
-        nn(early_stop_lim=False)
-    with pytest.raises(TypeError):
         nn(xHI='false')
     with pytest.raises(TypeError):
         nn(resume=10)
@@ -69,7 +67,7 @@ def test_process_nn():
 
     process(10, z, data_location='21cmGEM_data/', base_dir='base_dir/')
     nn(batch_size=451, layer_sizes=[], random_seed=10,
-       base_dir='base_dir/')
+       base_dir='base_dir/', early_stop=True)
 
     dir = ['model_dir/', 'base_dir/']
     for i in range(len(dir)):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -65,7 +65,7 @@ def test_process_nn():
         nn(loss_function='foobar')
 
     process(10, z, data_location='21cmGEM_data/', base_dir='base_dir/')
-    nn(batch_size=451, layer_sizes=[], random_seed=10,
+    nn(batch_size=451, layer_sizes=[], random_seed=10, epochs=30,
        base_dir='base_dir/', early_stop=True)
 
     dir = ['model_dir/', 'base_dir/']

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -5,10 +5,10 @@ from globalemu.downloads import download
 import os
 import shutil
 import pytest
-import requests
 
 params = [0.25, 30, 2, 0.056, 1.3, 2, 30]
 z = np.arange(10, 20, 100)
+
 
 def test_existing_dir():
     if os.path.exists('T_release/'):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,6 +1,5 @@
 import numpy as np
 from globalemu.preprocess import process
-import requests
 import os
 import pytest
 import pandas as pd


### PR DESCRIPTION
I've added test loss evaluation and proper early stopping, which is something that has been missing from this code base. This solves #10.

Test loss is saved in the results directory as `test_loss_history.txt` and early stopping is defined by

```python
if self.early_stop:
      if len(test_loss_results) > 20:
          delta = 2*np.abs(test_loss_results[-21] - \
              test_loss_results[-1])/ \
              (test_loss_results[-21] + test_loss_results[-1])
              
          if delta*100 < 1e-2:
              print('Early Stopped: {:.5f}'.format(delta.numpy()*100) +
                    ' < 1e-2')
              print('Epochs used = ' + str(len(test_loss_results)))
              break
```

i.e. if the percentage difference between the most recent evaluation of the test loss is < 0.01 percent different to the test loss 20 epochs previous, the code early stops.

Need to write tests to cover this code and check against pep8 the code.
