### PR TITLE
Flush prints during network training

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :globalemu: Robust Global 21-cm Signal Emulation
 :Author: Harry Thomas Jones Bevins
-:Version: 1.6.0
+:Version: 1.6.1
 :Homepage: https://github.com/htjb/globalemu
 :Documentation: https://globalemu.readthedocs.io/
 

--- a/globalemu/network.py
+++ b/globalemu/network.py
@@ -298,7 +298,7 @@ class nn():
                 'Epoch: {:03d}, Loss: {:.5f}, Test Loss: {:.5f},'
                 .format(epoch, epoch_loss_avg.result(), test_loss_results[-1])
                 + 'RMSE: {:.5f}, Time: {:.3f}'
-                .format(epoch_rmse_avg.result(), e-s))
+                .format(epoch_rmse_avg.result(), e-s), flush=True)
 
             if self.early_stop:
                 if len(test_loss_results) > 20:
@@ -309,8 +309,8 @@ class nn():
 
                     if delta*100 < 1e-2:
                         print('Early Stopped: {:.5f}'.format(delta.numpy()*100)
-                              + ' < 1e-2')
-                        print('Epochs used = ' + str(len(test_loss_results)))
+                              + ' < 1e-2', flush=True)
+                        print('Epochs used = ' + str(len(test_loss_results)), flush=True)
                         break
 
             if (epoch + 1) % 10 == 0:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme(short=False):
 
 setup(
     name='globalemu',
-    version='1.6.0',
+    version='1.6.1',
     description='globalemu: Robust and Fast Global 21-cm Signal Emulation',
     long_description=readme(),
     author='Harry T. J. Bevins',


### PR DESCRIPTION
On some high-performance computing clusters, the print buffer is not flushed during the evaluation of `nn`. As a result, the `print` statements that output epoch progress and the current loss function value are all printed at the end of `nn` evaluation rather than during it. 

This PR adds `flush = True` to the `print` statements in `nn` so that the buffer is forcibly pushed, meaning the progress statements are output as `nn` is ongoing. This is primarily useful for longer training jobs to see how close to completion they are.