### PR TITLE
Test preprocessing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :globalemu: Robust Global 21-cm Signal Emulation
 :Author: Harry Thomas Jones Bevins
-:Version: 1.8.0
+:Version: 1.8.1
 :Homepage: https://github.com/htjb/globalemu
 :Documentation: https://globalemu.readthedocs.io/
 

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -73,13 +73,9 @@ class process():
                 data set or not. Set to True by default as this is advised for
                 training both neutral fraction and global signal emulators.
 
-        logs: **list / default: [0, 1, 2]**
+        logs: **list / default: []**
             | The indices corresponding to the astrophysical parameters in
-                "train_data.txt" that need to be logged. The default assumes
-                that the first three columns in "train_data.txt" are
-                :math:`{f_*}` (star formation efficiency),
-                :math:`{V_c}` (minimum virial circular velocity) and
-                :math:`{f_x}` (X-ray efficieny).
+                "train_data.txt" that need to be logged.
     """
 
     def __init__(self, num, z, **kwargs):
@@ -137,7 +133,7 @@ class process():
             if type(bool_kwargs[i]) is not bool:
                 raise TypeError(bool_strings[i] + " must be a bool.")
 
-        self.logs = kwargs.pop('logs', [0, 1, 2])
+        self.logs = kwargs.pop('logs', [])
         if type(self.logs) is not list:
             raise TypeError("'logs' must be a list.")
 

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -166,7 +166,6 @@ class process():
             train_data = full_train_data.copy()
             if self.preprocess_settings['AFB'] is True:
                 train_labels = full_train_labels.copy() - res.deltaT
-                test_labels -= res.deltaT
             else:
                 train_labels = full_train_labels.copy()
         else:
@@ -185,10 +184,14 @@ class process():
                     train_data.append(full_train_data[i, :])
                     if self.preprocess_settings['AFB'] is True:
                         train_labels.append(full_train_labels[i] - res.deltaT)
+                        
                     else:
                         train_labels.append(full_train_labels[i])
             train_data, train_labels = np.array(train_data), \
                 np.array(train_labels)
+        
+        if self.preprocess_settings['AFB'] is True:
+            test_labels = test_labels.copy() - res.deltaT
 
         log_train_data = []
         for i in range(train_data.shape[1]):

--- a/globalemu/preprocess.py
+++ b/globalemu/preprocess.py
@@ -267,9 +267,8 @@ class process():
             norm_train_labels = norm_train_labels.flatten()
             np.save(self.base_dir + 'labels_stds.npy', labels_stds)
 
-            test_labels_stds = test_labels.std()
             norm_test_labels = [
-                test_labels[i, :]/test_labels_stds
+                test_labels[i, :]/labels_stds
                 for i in range(test_labels.shape[0])]
             norm_test_labels = np.array(norm_test_labels)
 


### PR DESCRIPTION
Solves #25 (and #24).

So it turns out that if num != 'full' then the AFB was not subtracted from the test data even if AFB=True which would mess with the early stopping. Fortunately, if num=`full' (i.e. all the training data is used in training) the AFB was subtracted from the test data. Hopefully nobody was doing production runs with num != 'full'.

Also noticed that the test data was not being divided by the standard deviation of the training data but instead by the standard deviation of the test data. Rookie error.  Probably will have had a detrimental effect on the early stopping (in v1.7.0 and above I think). However, I think it would be minor, as we would expect the standard deviation of the test data and training data to be approximately equivalent if the test data is representative.

These errors will have only effected the early stopping algorithm that was introduced in #15. It will not have had any impact on the post-processing of predictions from the network and therefore will not have had a negative impact on the calculation of RMSEs for test data or other asessments of accuracy for example.

We can see this working properly now for training data

![train_example_processed_figures](https://github.com/htjb/globalemu/assets/40355093/48d40d4b-99b0-4d10-b3fa-5f8a3b633cb2)

and test data

![test_example_processed_figures](https://github.com/htjb/globalemu/assets/40355093/786ea884-5a98-43f7-a9e6-bd9203d77cc6)

Took the oportunity to change the default logging of input parameters as well.